### PR TITLE
Add HRRR processing of CAMELS basins

### DIFF
--- a/forcing_prep/config_hrrr.yaml
+++ b/forcing_prep/config_hrrr.yaml
@@ -4,7 +4,7 @@ basin_url_template: "s3://lynker-spatial/hydrofabric/v20.1/camels/Gage_{}.gpkg" 
 basins:
   #- 1022500 #may list out basins of interest, or simply specify 'all'
   - 'all'
-time_bgn: '2018-11-08' # YYYY-MM-DD, The earliest HRRR zarr data with precipitation begins on '2018-07-13'
+time_bgn: '2018-07-13' # YYYY-MM-DD, The earliest HRRR zarr data with precipitation begins on '2018-07-13'
 time_end: '2024-05-30' # YYYY-MM-DD
 
 cvar: 8 # Chunk size for variables. Default 8.

--- a/forcing_prep/config_hrrr.yaml
+++ b/forcing_prep/config_hrrr.yaml
@@ -1,0 +1,34 @@
+hrrr_source: 's3://hrrrzarr/sfc' # url of HRRR data stored as zarr files in s3
+aorc_year_url_template: "{source}/{year}.zarr" # filename format of AORC zarr data files
+basin_url_template: "s3://lynker-spatial/hydrofabric/v20.1/camels/Gage_{}.gpkg" # URL of CAMELS basin geopackages
+basins:
+  #- 1022500 #may list out basins of interest, or simply specify 'all'
+  - 'all'
+time_bgn: '2018-10-25' # YYYY-MM-DD, The earliest HRRR zarr data with precipitation begins on '2018-07-13'
+time_end: '2024-05-30' # YYYY-MM-DD
+
+cvar: 8 # Chunk size for variables. Default 8.
+ctime_max: 120 # The max chunk time frame. Units of hours.
+cid: -1 # The divide_id chunk size. Default -1 means all divide_ids in a basin. A small value may be needed for very large basins with many catchments.
+redo: false # Set to true if you want to ensure intermediate data files not read in from local storage
+
+out_dir: "{home_dir}/noaa/data/hrrr/redo" # The local storage data output directory. 
+
+x_lon_dim: 'projection_x_coordinate' # The longitude term in the HRRR dataset
+y_lat_dim: 'projection_y_coordinate' # The latitude term in the HRRR dataset
+level_vars_anl: # These are the non-forecasted data variables
+  - '2m_above_ground/TMP'
+  - '2m_above_ground/SPFH'
+  - 'surface/DLWRF'
+  - 'surface/DSWRF'
+  - 'surface/PRES'
+  - '10m_above_ground/UGRD'
+  - '10m_above_ground/VGRD'
+level_vars_fcst: # These are the forecasted data variables (likely only precip)
+  - 'surface/APCP_1hr_acc_fcst'
+fcst_hr: 0 # The hours into the future forecast for variables specified in level_vars_fcst. Default 0 means the nowcast. Must be >= 0 up to the max HRRR forecast hours (12 hours???).
+drop_vars: # Ignore these variables when merging forecast and nowcast xarray.Dataset objects. Default should likely just be ['forecast_period','forecast_reference_time'] 
+ - 'forecast_period'
+ - 'forecast_reference_time'
+ - 'height'
+ - 'pressure' 

--- a/forcing_prep/config_hrrr.yaml
+++ b/forcing_prep/config_hrrr.yaml
@@ -4,7 +4,7 @@ basin_url_template: "s3://lynker-spatial/hydrofabric/v20.1/camels/Gage_{}.gpkg" 
 basins:
   #- 1022500 #may list out basins of interest, or simply specify 'all'
   - 'all'
-time_bgn: '2018-10-25' # YYYY-MM-DD, The earliest HRRR zarr data with precipitation begins on '2018-07-13'
+time_bgn: '2018-11-08' # YYYY-MM-DD, The earliest HRRR zarr data with precipitation begins on '2018-07-13'
 time_end: '2024-05-30' # YYYY-MM-DD
 
 cvar: 8 # Chunk size for variables. Default 8.

--- a/forcing_prep/config_hrrr.yaml
+++ b/forcing_prep/config_hrrr.yaml
@@ -3,7 +3,7 @@ basin_url_template: "s3://lynker-spatial/hydrofabric/v20.1/camels/Gage_{}.gpkg" 
 basins:
   #- 1022500 #may list out basins of interest, or simply specify 'all'
   - 'all'
-time_bgn: '2018-11-08' # YYYY-MM-DD, The earliest HRRR zarr data with precipitation begins on '2018-07-13'
+time_bgn: '2018-07-13' # YYYY-MM-DD, The earliest HRRR zarr data with precipitation begins on '2018-07-13'
 time_end: '2024-05-30' # YYYY-MM-DD
 
 cvar: 8 # Chunk size for variables. Default 8.
@@ -11,7 +11,7 @@ ctime_max: 120 # The max chunk time frame. Units of hours.
 cid: -1 # The divide_id chunk size. Default -1 means all divide_ids in a basin. A small value may be needed for very large basins with many catchments.
 redo: false # Set to true if you want to ensure intermediate data files not read in from local storage
 
-out_dir: "{home_dir}/noaa/data/hrrr/redo" # The local storage data output directory. 
+out_dir: "{home_dir}/noaa/data/hrrr/out" # The local storage data output directory. 
 
 x_lon_dim: 'projection_x_coordinate' # The longitude term in the HRRR dataset
 y_lat_dim: 'projection_y_coordinate' # The latitude term in the HRRR dataset

--- a/forcing_prep/config_hrrr.yaml
+++ b/forcing_prep/config_hrrr.yaml
@@ -1,5 +1,4 @@
 hrrr_source: 's3://hrrrzarr/sfc' # url of HRRR data stored as zarr files in s3
-aorc_year_url_template: "{source}/{year}.zarr" # filename format of AORC zarr data files
 basin_url_template: "s3://lynker-spatial/hydrofabric/v20.1/camels/Gage_{}.gpkg" # URL of CAMELS basin geopackages
 basins:
   #- 1022500 #may list out basins of interest, or simply specify 'all'

--- a/forcing_prep/generate.py
+++ b/forcing_prep/generate.py
@@ -28,92 +28,10 @@ import geopandas as gpd
 import numpy as np
 import s3fs
 import xarray as xr
-from dask.diagnostics import ProgressBar
 
-from aggregate import window_aggregate
-from weights import get_all_cov, get_weights_df
+from geo_proc import process_geo_data
 
 dask.config.set(pool=ThreadPool(12))
-import dask.dataframe as ddf
-
-
-def process_geo_data(gdf, data, name, y_lat_dim, x_lon_dim,out_dir = '', redo = False, cvar = 8, ctime_max = 120, cid = -1):
-    print("Slicing data to domain")
-    # Only need to load the raster for the geo data extent
-    extent = gdf.total_bounds
-    lats = slice(extent[1], extent[3])
-    lons = slice(extent[0], extent[2])
-    # In  case the data is upside down, flip the y axis
-    flipped = bool(len(data[y_lat_dim]) > 1 and data[y_lat_dim][1] > data[y_lat_dim][0])
-    if flipped:
-        data = data.sel({y_lat_dim : slice(None, None, -1)})
-        # in order for xarray to use slice indexing, need to ensure
-        # the lats slice is high to low when the latitude index is reversed
-        lats = slice(extent[3], extent[1])
-    data = data.sel(indexers = {x_lon_dim:lons, y_lat_dim:lats})
-    # Load or compute coverage masks
-    save = Path(f"{out_dir}/{name}_coverage.parquet")
-    if save.exists() and redo != True:
-        print(f"Reading {name} coverage from file")
-        coverage = ddf.read_parquet(save).compute()
-    else:
-        # If we don't have weights cached, compute and save them
-        weight_raster = (
-            data[next(iter(data.keys()))]
-            .isel(time=0)
-            .sel(indexers = {x_lon_dim:lons, y_lat_dim:lats})
-            .compute()
-        )
-        print("Computing Weights")
-        weights_df = get_weights_df(gdf, weight_raster)
-        print("Creating Coverage")
-        coverage = get_all_cov(data, weights_df, y_lat_dim = y_lat_dim, x_lon_dim = x_lon_dim)
-        coverage.to_parquet(save)
-    print("Processing the following raster data set")
-    print(data)
-    # Stack all the raster variables into a single multi-dimension array
-    # This makes the windowing algorithm much more efficient as it can broadcast
-    # operations arcoss all the variable data at once
-    data = data.to_dataarray()
-
-
-    # Chunk params were chosen based on processing HUC 01 (19k geometries) within reasonable
-    # time and memory pressure.  These can have serious performance implications on large
-    # geo data sets!!!
-    ctime = np.min([ctime_max, len(data['time'])])
-    
-    # On huc01 when this is not 1, you get
-    # KeyError: ('<this-array>-agg_xr5-1d8d7d6b0dd083c3658d89ffacb65555', 0, 0, 1)
-    # when the results try to join :confused:
-    # but seemed to work on on smaller domains (e.g. a camels basin)
-
-    # Rechunk data through time, but ensure the entire spatial extent is in mem
-    data = data.chunk(
-        {"variable": cvar, y_lat_dim: -1, x_lon_dim: -1, "time": ctime}
-    )
-    # Build the template data array for the outputs
-    coords = {
-        "time": data.time,
-        "divide_id": gdf["divide_id"].sort_values(),
-        "variable": data.coords["variable"].values,
-    }
-    dims = ["variable", "time", "divide_id"]
-    shp = (
-        len(data.coords["variable"]),
-        data.time.size,
-        len(gdf["divide_id"]),
-    )
-    var = xr.DataArray(np.zeros(shp), coords=coords, dims=dims)
-    # It is important to make sure these chunks align with the data chunks!
-    var = var.chunk({"variable": cvar, "time": ctime, "divide_id": cid})
-    result = data.map_blocks(window_aggregate, args=(coverage,), template=var)
-    # Perform the computations
-    with ProgressBar():
-        result = result.compute()
-    # Unstack the variables back into a dataset
-    result = result.to_dataset(dim="variable")
-    return result
-
 
 if __name__ == "__main__":
 

--- a/forcing_prep/generate_hrrr.py
+++ b/forcing_prep/generate_hrrr.py
@@ -1,0 +1,190 @@
+'''
+Process HRRR data with CAMELS basins
+
+'''
+
+
+import argparse
+import yaml
+from multiprocessing.pool import ThreadPool
+from pathlib import Path
+
+import pandas as pd
+
+import dask
+import dask.delayed
+import geopandas as gpd
+import numpy as np
+import s3fs
+import xarray as xr
+from dask.diagnostics import ProgressBar
+
+
+# from aggregate import window_aggregate
+# from weights import get_all_cov, get_weights_df
+# The custom functions
+from hrrr_proc import prep_date_time_range, _map_open_files_hrrrzarr, _gen_hrrr_zarr_urls
+from geo_proc import process_geo_data
+
+dask.config.set(pool=ThreadPool(12))
+import dask.dataframe as ddf
+
+import pandas as pd
+from functools import partial
+from cartopy import crs as ccrs
+import exactextract
+import zarr # An xarray.open_mfdataset dependency
+import rioxarray # dependency in exactextract
+import rasterio # dependency in exactextract
+
+def _preprocess_sel_time(xda, apcp_fcst):
+    # This helps select the forecast hour of interest, rather than grab all forecasted hours
+    # reference: how to pass arguments in preprocess:  https://github.com/pydata/xarray/pull/6825
+    xda = xda.isel(time=apcp_fcst)
+    return xda
+
+# def _gen_hrrr_zarr_urls(date, level_vars_anl = None, level_vars_fcst=None, fcst_hr=0, bucket_subf = 's3://hrrrzarr/sfc'):
+#     # Zarr data file structure follows e.g. 'hrrrzarr/sfc/20240430/20240430_22z_anl.zarr/2m_above_ground/TMP/2m_above_ground'
+#     fs = s3fs.S3FileSystem(anon=True)
+#     bucket_subfolder_date = f'{bucket_subf}/{date}/'
+#     try:
+#         times_anl = [x for x in fs.ls(bucket_subfolder_date) if '_anl.zarr' in x]
+#         if not times_anl:
+#             raise(Warning(f'Could not list bucket for {date} inside {bucket_subfolder_date}. Skipping.'))
+#         urls_anl = _build_zarr_urls(times_anl, level_vars_anl)
+#         # Build forecast urls based on forecast hour
+#         times_avail_fcst = [x for x in fs.ls(bucket_subfolder_date) if '_fcst.zarr' in x]
+#         times_fcst = _fcst_url_find(times_avail_fcst, fcst_hr, bucket_subf, date)
+#         urls_fcst = _build_zarr_urls(times_fcst, level_vars_fcst)
+#     except:
+#         urls_fcst = list()
+#         urls_anl = list()
+#     return urls_fcst, urls_anl
+
+if __name__ == "__main__":
+
+    # parser = argparse.ArgumentParser(description='Process the YAML config file.')
+    # parser.add_argument('config_path', type=str, help='Path to the YAML configuration file')
+    # args = parser.parse_args()
+    
+    # # Load the YAML configuration file
+    # with open(args.config_path, 'r') as file:
+    #     config = yaml.safe_load(file)
+
+    # cvar = config['cvar']
+    # ctime_max = config['ctime_max']
+    # cid = config['cid']
+    # redo = config['redo']
+    # x_lon_dim = config['x_lon_dim']
+    # y_lat_dim = config['y_lat_dim']
+    # out_dir = Path(config['out_dir'].format(home_dir=str(Path.home())))
+
+    time_bgn = '2018-08-13'# '2018-07-13'
+    time_end = '2024-04-30'
+
+    level_vars_anl = ['2m_above_ground/TMP',
+                '2m_above_ground/SPFH','surface/DLWRF',
+                'surface/DSWRF','surface/PRES',
+                '10m_above_ground/UGRD','10m_above_ground/VGRD']
+    level_vars_fcst = ['surface/APCP_1hr_acc_fcst']
+    apcp_fcst_hr = 0 # TODO add
+    _bucket_subf = 's3://hrrrzarr/sfc'
+    drop_vars = ['forecast_period','forecast_reference_time','height', 'pressure'] # Ignore these variables when merging forecast and nowcast xarray.Dataset objects. Default should likely just be ['forecast_period','forecast_reference_time'] 
+    _hydrofab_source = "s3://lynker-spatial/hydrofabric/v20.1/camels/"
+    _basin_url = _hydrofab_source + "Gage_{}.gpkg"
+    basins = [1022500]
+
+    y_lat_dim = 'projection_y_coordinate'
+    x_lon_dim = 'projection_x_coordinate'
+
+    out_dir = f'{Path.home()}/noaa/data/hrrr/redo'
+
+    Path.mkdir(Path(out_dir), exist_ok = True)
+
+    # Define the partial function used for processing time in forecast data:
+    partial_func = partial(_preprocess_sel_time, apcp_fcst = apcp_fcst_hr)
+
+    all_dates, all_hours = prep_date_time_range(time_bgn, time_end)
+    gpkgs = [_basin_url.format(id) for id in basins]
+
+
+    # HRRR grid uses the Lambert Conformal projection:
+    proj = ccrs.LambertConformal(central_longitude=262.5, 
+                                    central_latitude=38.5, 
+                                    standard_parallels=(38.5, 38.5),
+                                        globe=ccrs.Globe(semimajor_axis=6371229,
+                                                        semiminor_axis=6371229))
+
+
+    fs = s3fs.S3FileSystem(anon=True)
+
+    for b in basins:
+
+        # read the geopackage from s3
+        gdf = gpd.read_file(
+            fs.open(_basin_url.format(b)), driver="gpkg", layer="divides").to_crs(proj)
+
+        for date in all_dates:
+            print(f'Processing basin {b} on {date}')
+            try:
+                urls_fcst, urls_anl =  _gen_hrrr_zarr_urls(date=date, level_vars_anl=level_vars_anl, level_vars_fcst=level_vars_fcst,fcst_hr=apcp_fcst_hr, bucket_subf = _bucket_subf)
+                #urls_fcst, urls_anl = _gen_hrrr_zarr_urls(date, level_vars_anl, level_vars_fcst,apcp_fcst_hr, _bucket_subf)
+            except:
+                raise ValueError(f'Could not list bucket for {date} inside {_bucket_subf}.\nConsider sf.ls() in lieu of explicit build.')
+
+            skip_fcst = skip_anl = False
+            if len(urls_fcst) == 0 == len(urls_anl) == 0:
+                print(f'No data exist for {date}') 
+                continue
+            elif len(urls_fcst) == 0:
+                print(f'No forecasted precip data available on {date}')
+                skip_fcst = True
+            elif len(urls_anl) == 0:
+                print(f'No analysis data available on {date}')
+                skip_anl = True
+            elif len(urls_fcst[0]) == 0:
+                raise Warning(f'No forecast urls exist for {date}') # e.g. '20180711'
+
+            # Now run a data pull
+            try:
+                if not skip_anl:
+                    dat_anl = _map_open_files_hrrrzarr(urls_ls = urls_anl, concat_dim = ['time',None])
+                else: 
+                    dat_anl = xr.Dataset()
+                if not skip_fcst:
+                    dat_fcst = _map_open_files_hrrrzarr(urls_ls = urls_fcst, concat_dim = ['time',None], preprocess = partial_func)
+                else:
+                    dat_fcst = xr.Dataset()
+            except: # Example: 20190506
+                print(f'Initial hrrrzarr file opening unsuccessful on {date}. Waiting 30s and reattempting:') 
+                import time
+                time.sleep(30) # wait 30 seconds and try again
+                try:
+                    if not skip_anl:
+                        dat_anl = _map_open_files_hrrrzarr(urls_ls = urls_anl, concat_dim = ['time',None])
+                    else: 
+                        dat_anl = xr.Dataset()
+                    if not skip_fcst:
+                        dat_fcst = _map_open_files_hrrrzarr(urls_ls = urls_fcst, concat_dim = ['time',None], preprocess = partial_func)
+                    else:
+                        dat_fcst = xr.Dataset()
+                except:
+                    raise ValueError(f'TODO figure out what to do for {date}') 
+
+            dat_anl = dat_anl.drop_vars([x for x in dat_anl.data_vars.keys() if x in drop_vars])
+            dat_fcst = dat_fcst.drop_vars([x for x in dat_fcst.data_vars.keys() if x in drop_vars])
+            forcing = dat_anl.merge(dat_fcst)   
+
+            df = process_geo_data(gdf, data=forcing, name = b, y_lat_dim = y_lat_dim, x_lon_dim = x_lon_dim, out_dir = out_dir, redo = True)
+            df = df.to_dataframe()
+                
+            save_path_base = f'{out_dir}/camels_{b}_{date}'
+
+            # print(df)
+            cats = df.groupby("divide_id")
+            path = Path(save_path_base)
+            Path.mkdir(path, exist_ok=True)
+            for name, data in cats:
+                data.to_csv(path / f"{name}.csv")
+            agg = df.groupby("time").mean()
+            agg.to_csv(path / f"camels_{b}_agg.csv")

--- a/forcing_prep/generate_hrrr.py
+++ b/forcing_prep/generate_hrrr.py
@@ -69,8 +69,10 @@ if __name__ == "__main__":
     basins = config['basins']
     _level_vars_anl = config['level_vars_anl']
     _level_vars_fcst = config['level_vars_fcst']
-    apcp_fcst_hr = config['fcst_hr']
+    apcp_fcst_hr = config['fcst_hr'] # when the 'nowcast' is desired, this should be 0
     _drop_vars = config['drop_vars']
+
+    actual_fcst_dt_hr = apcp_fcst_hr + 1 # for accumulated precip, the actual forecast timestamp is accumulated precip at the end of an hour, so add 1 hour. E.g. if nowcast is desired, apcp_fcst_hr = 0, but we need to add 1 hour to represent the accumulated precip that actually happened.
     ####
     fs = s3fs.S3FileSystem(anon=True)
     # List all the basins inside the hydrofabric s3 bucket path
@@ -129,7 +131,7 @@ if __name__ == "__main__":
                 else: 
                     dat_anl = xr.Dataset()
                 if not skip_fcst:
-                    dat_fcst = _map_open_files_hrrrzarr(urls_ls = urls_fcst, concat_dim = ['time',None], preprocess = partial_func)
+                    dat_fcst = _map_open_files_hrrrzarr(urls_ls = urls_fcst, concat_dim = ['time',None], preprocess = partial_func,fcst_hr=actual_fcst_dt_hr)
                 else:
                     dat_fcst = xr.Dataset()
             except: # Example: 20190506
@@ -142,7 +144,7 @@ if __name__ == "__main__":
                     else: 
                         dat_anl = xr.Dataset()
                     if not skip_fcst:
-                        dat_fcst = _map_open_files_hrrrzarr(urls_ls = urls_fcst, concat_dim = ['time',None], preprocess = partial_func)
+                        dat_fcst = _map_open_files_hrrrzarr(urls_ls = urls_fcst, concat_dim = ['time',None], preprocess = partial_func,fcst_hr=actual_fcst_dt_hr)
                     else:
                         dat_fcst = xr.Dataset()
                 except:

--- a/forcing_prep/generate_hrrr.py
+++ b/forcing_prep/generate_hrrr.py
@@ -160,6 +160,7 @@ if __name__ == "__main__":
             path = Path(save_path_base)
             Path.mkdir(path, exist_ok=True)
             for name, data in cats:
+                data = data.droplevel('divide_id')
                 data.to_csv(path / f"{name}.csv")
             agg = df.groupby("time").mean()
             agg.to_csv(path / f"camels_{b}_agg.csv")

--- a/forcing_prep/geo_proc.py
+++ b/forcing_prep/geo_proc.py
@@ -1,0 +1,109 @@
+'''
+@title: Process weights of raster grid data spanning catchment boundaries
+@author: Nels Frazier
+@author: Guy Litt
+@description: Given a geodataframe representing catchment(s) boundaries and a raster dataset,
+compute the mean data values spanning the catchment(s) boundaries.
+@param: gdf  geodataframe of catchments
+@param: data xarray dataset of raster data
+@param:
+
+# Changelog / contributions
+    2024-May Originally created, NF
+    2024-06-18 minor adaptations to flipped dataset check, data selection NF, GL
+
+'''
+
+
+import zarr
+from pathlib import Path
+from multiprocessing.pool import ThreadPool
+
+import dask
+import dask.delayed
+import geopandas as gpd
+import numpy as np
+import s3fs
+import xarray as xr
+from dask.diagnostics import ProgressBar
+import dask.dataframe as ddf
+
+from aggregate import window_aggregate
+from weights import get_all_cov, get_weights_df
+
+def process_geo_data(gdf, data, name, y_lat_dim, x_lon_dim,out_dir = '', redo = False, cvar = 8, ctime_max = 120, cid = -1):
+    print("Slicing data to domain")
+    # Only need to load the raster for the geo data extent
+    extent = gdf.total_bounds
+    lats = slice(extent[1], extent[3])
+    lons = slice(extent[0], extent[2])
+    # In  case the data is upside down, flip the y axis
+    flipped = bool(len(data[y_lat_dim]) > 1 and data[y_lat_dim][1] > data[y_lat_dim][0])
+    if flipped:
+        data = data.sel({y_lat_dim : slice(None, None, -1)})
+        # in order for xarray to use slice indexing, need to ensure
+        # the lats slice is high to low when the latitude index is reversed
+        lats = slice(extent[3], extent[1])
+    data = data.sel(indexers = {x_lon_dim:lons, y_lat_dim:lats})
+    # Load or compute coverage masks
+    save = Path(f"{out_dir}/{name}_coverage.parquet")
+    if save.exists() and redo != True:
+        print(f"Reading {name} coverage from file")
+        coverage = ddf.read_parquet(save).compute()
+    else:
+        # If we don't have weights cached, compute and save them
+        weight_raster = (
+            data[next(iter(data.keys()))]
+            .isel(time=0)
+            .sel(indexers = {x_lon_dim:lons, y_lat_dim:lats})
+            .compute()
+        )
+        print("Computing Weights")
+        weights_df = get_weights_df(gdf, weight_raster)
+        print("Creating Coverage")
+        coverage = get_all_cov(data, weights_df, y_lat_dim = y_lat_dim, x_lon_dim = x_lon_dim)
+        coverage.to_parquet(save)
+    print("Processing the following raster data set")
+    print(data)
+    # Stack all the raster variables into a single multi-dimension array
+    # This makes the windowing algorithm much more efficient as it can broadcast
+    # operations arcoss all the variable data at once
+    data = data.to_dataarray()
+
+
+    # Chunk params were chosen based on processing HUC 01 (19k geometries) within reasonable
+    # time and memory pressure.  These can have serious performance implications on large
+    # geo data sets!!!
+    ctime = np.min([ctime_max, len(data['time'])])
+    
+    # On huc01 when this is not 1, you get
+    # KeyError: ('<this-array>-agg_xr5-1d8d7d6b0dd083c3658d89ffacb65555', 0, 0, 1)
+    # when the results try to join :confused:
+    # but seemed to work on on smaller domains (e.g. a camels basin)
+
+    # Rechunk data through time, but ensure the entire spatial extent is in mem
+    data = data.chunk(
+        {"variable": cvar, y_lat_dim: -1, x_lon_dim: -1, "time": ctime}
+    )
+    # Build the template data array for the outputs
+    coords = {
+        "time": data.time,
+        "divide_id": gdf["divide_id"].sort_values(),
+        "variable": data.coords["variable"].values,
+    }
+    dims = ["variable", "time", "divide_id"]
+    shp = (
+        len(data.coords["variable"]),
+        data.time.size,
+        len(gdf["divide_id"]),
+    )
+    var = xr.DataArray(np.zeros(shp), coords=coords, dims=dims)
+    # It is important to make sure these chunks align with the data chunks!
+    var = var.chunk({"variable": cvar, "time": ctime, "divide_id": cid})
+    result = data.map_blocks(window_aggregate, args=(coverage,), template=var)
+    # Perform the computations
+    with ProgressBar():
+        result = result.compute()
+    # Unstack the variables back into a dataset
+    result = result.to_dataset(dim="variable")
+    return result

--- a/forcing_prep/geo_proc.py
+++ b/forcing_prep/geo_proc.py
@@ -1,12 +1,7 @@
 '''
 @title: Process weights of raster grid data spanning catchment boundaries
-@author: Nels Frazier
-@author: Guy Litt
-@description: Given a geodataframe representing catchment(s) boundaries and a raster dataset,
-compute the mean data values spanning the catchment(s) boundaries.
-@param: gdf  geodataframe of catchments
-@param: data xarray dataset of raster data
-@param:
+@author: Nels Frazier <nfrazier@lynker.com>
+@author: Guy Litt <glitt@lynker.com>
 
 # Changelog / contributions
     2024-May Originally created, NF
@@ -32,6 +27,20 @@ from aggregate import window_aggregate
 from weights import get_all_cov, get_weights_df
 
 def process_geo_data(gdf, data, name, y_lat_dim, x_lon_dim,out_dir = '', redo = False, cvar = 8, ctime_max = 120, cid = -1):
+    '''
+    @description: Given a geodataframe representing catchment(s) boundaries and a raster dataset,
+    compute the mean data values spanning the catchment(s) boundaries.
+    @param: gdf  geodataframe of catchments
+    @param: data xarray dataset of raster data
+    @param: name A unique file name used for saving catchment-specific grid weights. The basin id is ideal.
+    @param: y_lat_dim the latitude identifier in the xarray dataset \code{data}
+    @param: x_lon_dim the longitude identifier in the xarray dataset \code{data}
+    @param: out_dir the desired save directory for catchment-specific grid weights
+    @param: redo boolean default False. Should previously saved catchment grid weights be read in if they have already been created? If False, weights are regenerated
+    @param: cvar int default 8; Chunk size for variables. Default 8.
+    @param: ctime_max int default 120; The max chunk time frame. Units of hours.
+    @param: cid int default -1; The divide_id chunk size. Default -1 means all divide_ids in a basin. A small value may be needed for very large basins with many catchments.
+    '''
     print("Slicing data to domain")
     # Only need to load the raster for the geo data extent
     extent = gdf.total_bounds

--- a/forcing_prep/hrrr_proc.py
+++ b/forcing_prep/hrrr_proc.py
@@ -1,0 +1,233 @@
+'''
+A collection processing zarr-formatted HRRR datasets 
+
+'''
+import pandas as pd
+import numpy as np
+import s3fs
+from pathlib import Path
+import datetime as dt
+from cartopy import crs as ccrs
+import dask
+import dask.delayed
+import xarray as xr
+import warnings
+
+def prep_date_time_range(time_bgn, time_end):
+    '''
+    Prepare range of dates as a list, formatted YMD based on HRRR urls
+    '''
+    time_range = pd.date_range(start =time_bgn, end = time_end, freq = 'D')
+    dates = [str(dt.year)+ f'{dt.month:02d}' + f'{dt.day:02d}' for dt in time_range]
+    all_hours = [f"{num:02d}" for num in range(24)]
+    #hour = '00' # The forecast hour *Note that some hours are missing!!
+    return dates, all_hours
+
+def _build_zarr_urls(zarr_paths, level_vars):
+    ls_urls = list()
+    for levvara in level_vars:
+        leva = levvara.split('/')[0]
+        vara = levvara.split('/')[1]
+        dat_urls1 = [f'{x}/{leva}/{vara}/{leva}' for x in zarr_paths] # data
+        dat_urls2 = [f'{x}/{leva}/{vara}' for x in zarr_paths] # metadata
+        zip_urls = [x for x in zip(dat_urls1,dat_urls2)]
+        #zip_urls = list(map(list, zip(dat_urls1, dat_urls2)))
+        ls_urls.append(zip_urls)
+    return ls_urls
+
+def _fcst_url_find(times_avail, fcst_hr, bucket_subf, date):
+    '''
+    The forecast data represent time into the future and this changes the date/hour to align with nowcast data.
+    For example if forecast hour = 03, HRRR data extract the forecasted data from hours spanning 03 to 04,
+        e.g. accumulated precipitation after one hour has passed by 04:00. 
+    '''
+    fs = s3fs.S3FileSystem(anon=True)
+    # Find the url date - hour pairings corresponding to the desired forecasting hour
+    if int(fcst_hr) > 23:
+        raise ValueError('Forecast data subsetting has only been designed for forecasts up to 24 hours in advance. Please set fcst_hr to values from 0 to 23.')
+
+    times_fcst_og = [x for x in times_avail if '_fcst.zarr' in x] # The standard URLS for a single day
+    # Determine subset of day's timestamps desired
+    str_max = f"_{24-(fcst_hr+1):02d}z_"
+    idx_max = [x.item() for x in np.where(np.char.find(np.array(times_fcst_og), str_max) >-1) ]
+    if len(idx_max) != 1:
+        for x in np.arange(0,24-(fcst_hr+1))[::-1]:
+            str_max = f"_{x:02d}z_"
+            idx_max = [x.item() for x in np.where(np.char.find(np.array(times_fcst_og), str_max) >-1)]
+            if len(idx_max) == 1:
+                break
+    sub_times_fcst_og = times_fcst_og[0:int(idx_max[0])]
+
+    # Now find previous day's hours of interest:
+    back_time = pd.to_datetime(date, format = '%Y%m%d') - pd.Timedelta(fcst_hr+1, unit='hour')
+    back_date = str(back_time)[0:10].replace('-','')
+    back_hour = f'_{24-(fcst_hr+1):02d}z_'
+    bucket_subfolder_backdate = f'{bucket_subf}/{back_date}/'
+    times_avail_back = [x for x in fs.ls(bucket_subfolder_backdate) if '_fcst.zarr' in x ]
+    times_sel_back = list()
+    
+    for x in np.arange((24-(fcst_hr+1)),24):
+        str_find_back = f'_{x:02d}z_'
+        times_sel_back.append(times_avail_back[[x.item() for x in np.where(np.char.find(times_avail_back, str_find_back)>-1)][0]])
+    urls_fcst = times_sel_back + sub_times_fcst_og
+    return urls_fcst
+
+def _gen_hrrr_zarr_urls(date, level_vars_anl = None, level_vars_fcst=None, fcst_hr=0, bucket_subf = 's3://hrrrzarr/sfc'):
+    # Zarr data file structure follows e.g. 'hrrrzarr/sfc/20240430/20240430_22z_anl.zarr/2m_above_ground/TMP/2m_above_ground'
+    fs = s3fs.S3FileSystem(anon=True)
+    bucket_subfolder_date = f'{bucket_subf}/{date}/'
+    try:
+        times_anl = [x for x in fs.ls(bucket_subfolder_date) if '_anl.zarr' in x]
+        if not times_anl:
+            raise(Warning(f'Could not list bucket for {date} inside {bucket_subfolder_date}. Skipping.'))
+        urls_anl = _build_zarr_urls(times_anl, level_vars_anl)
+        # Build forecast urls based on forecast hour
+        times_avail_fcst = [x for x in fs.ls(bucket_subfolder_date) if '_fcst.zarr' in x]
+        times_fcst = _fcst_url_find(times_avail_fcst, fcst_hr, bucket_subf, date)
+        urls_fcst = _build_zarr_urls(times_fcst, level_vars_fcst)
+    except:
+        urls_fcst = list()
+        urls_anl = list()
+    return urls_fcst, urls_anl
+
+def _check_hrrrzarr_url_time_vs_data_time(urls_ls, ls_vars,drop_vars=None):
+    '''
+    Checks to see if any timestamps specified in a zarr url do not agree
+     with timestamps retrieved in data, and provides new data if needed.
+    @param: urls_ls A list of urls organized by var[timebythehour[zarr url, metadata url]]
+    @param: ls_vars: A list of datasets, each list item unique to a HRRR variable
+    @return: subdat_ls, ls_wrong_ts where subdat_ls is a new version of ls_vars, and ls_wrong_ts is a list of boolean if any variable changed
+    @seealso: _map_open_files_hrrrzarr()
+    '''
+    ctr_ls = -1
+    subdat_ls = list()
+    ls_wrong_ts = list()
+    xr_cmbo = xr.Dataset()
+    for subdat in ls_vars:
+        # First check to see that time index is present. If not, skip the variable (e.g. 20201124 PRES):
+        if 'time' not in subdat.dims:
+            continue      
+
+        if drop_vars != None:
+            subdat = subdat.drop_vars([x for x in subdat.data_vars.keys() if x in drop_vars])
+        ctr_ls+=1
+        # Extract timestamps in url:
+        idx_chck = list()
+        for day_url in  urls_ls[ctr_ls]:
+            dt_url = pd.to_datetime(day_url[0].split('/')[3][0:11],format='%Y%m%d_%H')
+            idx_chck.append(np.where(subdat.time.data == dt_url))
+                    # Simplify the time indexes for keeps into a list of ints
+            idx_keep = [y[0] for y in [x[0] for x in idx_chck if x[0].size > 0]]
+
+        if len(idx_keep) < len(urls_ls[ctr_ls]):
+            ls_wrong_ts.append(True)
+        sub_ls_var = list()
+        for var_name, sub_da in subdat.items(): # loop across e/ dataarray to subset by time
+            sub_ls_var.append(sub_da.isel(time=idx_keep))
+        xr_var = xr.merge(sub_ls_var)
+        subdat_ls.append(xr.merge(sub_ls_var))
+    return subdat_ls, ls_wrong_ts
+
+
+def fxn():
+    # Goal: Suppress the following warning that is generated when running open_mfdataset
+    # "No index created for dimension time because variable time is not a coordinate. To create an index for time, please first call `.set_coords('time')` on this object."
+    warnings.warn("UserWarning", UserWarning)
+
+def _map_open_files_hrrrzarr(urls_ls, concat_dim = ['time',None], preprocess = None,drop_vars = None):
+    # Expect urls_ls to be a nested list as follows: [var[date-hour[paired urls]]]
+    fs = s3fs.S3FileSystem(anon=True)
+    # Map the urls
+    files_map = [[[s3fs.S3Map(z , s3=fs) for z in y] for y in x] for x in urls_ls]
+    # Problem: some variables needs to be read in using consolidated = False (e.g. DSWRF 20240430), which is much slower
+    ls_vars = list()
+    var_ctr = -1
+    for fvar in files_map:
+        var_ctr +=1
+        with warnings.catch_warnings():
+            # Suppress the UserWarning on 'time variable not a coordinate' that is generated when running open_mfdataset
+            warnings.simplefilter("ignore")
+            fxn()
+            # DO NOT set consolidated = True as some variables need consolidated = False
+            try:
+                ls_vars.append(xr.open_mfdataset(fvar, engine = 'zarr', parallel = True,
+                                            combine = 'nested',
+                                            preprocess = preprocess,
+                                            concat_dim = concat_dim)) 
+            except:
+                print('Could not successfully process urls. Attempting to process by the hour instead of day (this takes longer)')
+                var = urls_ls[var_ctr]
+                var_name = var[0][1].split('/')[-1]
+                print(f'Problematic variable includes: {var_name}')
+                
+                ls_hrs = list()
+                for hr in var: 
+                    try:
+                        hr_map = [s3fs.S3Map(h, s3=fs) for h in hr]
+                        check = (xr.open_mfdataset(hr_map, engine = 'zarr', parallel = True,
+                                        combine = 'nested',
+                                        preprocess = preprocess # TODO may need to handle a different pre-processing function in case failure occurs
+                                        ))  # Note no concat_dim when working with lowest 'resolution'
+                        # Add in expected data variable check:
+                        if not 'fcst' in var_name: # A forecast variable name likely does not have a 'time' variable, but rather a 'forecast_reference_time'
+                            must_have_vars = [x for x in concat_dim if x is not None] + [var_name]
+                        else: # Do not want 'time' to be expected in variables for the case of APCP_1hr_acc_fcst
+                            must_have_vars = [var_name]
+
+                        if not all([x in check.data_vars for x in must_have_vars]): # Example 20200318_22z DSWRF
+                            # Expected variables include 'time' and the var_name
+                            print(f'Skipping {var_name} because {' & '.join(must_have_vars)} are not present as variables in the dataset from {hr}. ')
+                            continue
+                    except: # Skip this one and head to the next
+                        print(f'Could not process {hr}. Skipping. Consider the preprocess function or faulty zarr data.')
+                        continue
+                    else:
+                        ls_hrs.append(check)
+                # Concatenate each hour's dataset into a full days' dataset:
+                if len(ls_hrs) > 0:
+                    sub_concat = xr.concat(ls_hrs,dim='time')
+                else:
+                    sub_concat = xr.Dataset()
+                ls_vars.append(sub_concat) # Add the variable's full day to list of variables
+    try: # Upon building list of variable-days, combine into a single dataset
+        # TODO On 20200727 why does everything go to 20200728T01 except for the variable PRES?
+        # TODO consider fixing how the urls were generated (e.g. [(x.time.data[1]) for x in ls_vars])
+        dat = xr.merge(ls_vars)
+    except: 
+        dat1 = xr.Dataset()
+        dat2 = xr.Dataset()
+        ctr = -1
+        for ls in ls_vars: # Perform over each variable 
+            if any(ls.get_index('time').duplicated()):
+                 # Eg. 20200914 'cannot reindex or align along dimension 'time' because the pandas index has duplicate values
+                 ls = ls.drop_duplicates(dim = ['time'], keep = 'last')
+            ctr += 1
+            print(ctr)
+            try:
+                dat1 = xr.merge([dat1,ls])
+            except:
+                try:
+                    dat2 = xr.merge([dat2, ls])
+                except: # If none of this data salvaging attempt works, just skip it
+                    print("PROBLEM HERE")
+           
+        if len(dat2.keys()) >0:
+            # Try to extract the data from dat2
+            try:
+                print("DO SOMETHING")
+            except:
+                print("DO SOMETHING 2")
+        dat = dat1
+    if any(dat.get_index('time').duplicated()): # Double check no timestamps were duplicated
+        print(f'Duplicated timestamps generated - removed.')
+        dat = dat.drop_duplicates(dim = ['time'], keep = 'last')
+
+    # Run timestamp checker:
+    subdat_ls, ls_wrong_ts = _check_hrrrzarr_url_time_vs_data_time(urls_ls, ls_vars,drop_vars)
+    # When unexpected timestamps exist, _check_hrrrzarr_url_time_vs_data_time removes them (e.g. 20200727T01 should return 20200728T01 for TMP
+    if any(ls_wrong_ts):
+        # There are more timestamps than expected.
+        dat = xr.merge(subdat_ls)
+    return dat
+
+


### PR DESCRIPTION
Key change w/r/t AORC: Moved the process_geo_data() function out of generate.py into a separate file geo_proc.py so that it can easily be used by both HRRR and AORC processing.

The HRRR processing is slow (~1 min/day of data/basin, running locally). There may be a potential to gain processing efficiency when calling xr.open_mfdataset(), but there are challenges with data inconsistencies.