### PR TITLE
NetCDF output capability and single geopackage processing option.

### DIFF
--- a/forcing_prep/config_aorc.yaml
+++ b/forcing_prep/config_aorc.yaml
@@ -1,5 +1,10 @@
 aorc_source: "s3://noaa-nws-aorc-v1-1-1km" # url of AORC data stored as zarr files in s3
 aorc_year_url_template: "{source}/{year}.zarr" # filename format of AORC zarr data files
+# These are camels specific configurations, if you wish to process a single
+# ngen hydrofabric geopackage, you can override the camels specifics by setting the following
+#gpkg: <path_to_geopkg>
+# in which case the following two keys are ignored and forcings are generated
+# for that single geopackage
 basin_url_template: "s3://lynker-spatial/hydrofabric/v20.1/camels/Gage_{basin_id}.gpkg" # URL of CAMELS basin geopackages
 basins:
   #- 1022500 #may list out basins of interest, or simply specify 'all'
@@ -14,3 +19,7 @@ redo: false # Set to true if you want to ensure intermediate data files not read
 x_lon_dim: "longitude" # The longitude term in the AORC dataset
 y_lat_dim: "latitude" # The latitude term in the AORC dataset
 out_dir: "{home_dir}/noaa/data/aorc" # The local storage data output directory. 
+
+# By default, will generate ngen compatible netcdf files, to generate CSV files
+# instead, set the following key with false
+#netcdf: false

--- a/forcing_prep/generate.py
+++ b/forcing_prep/generate.py
@@ -174,7 +174,7 @@ if __name__ == "__main__":
         basins = np.unique([Path(x).stem.split('_')[1] for x in  _s3.ls(base_path) if '/Gage_' in x])
 
     # Create a year-range output directory: 
-    year_str = '_to_'.join([str(x) for x in config['years']])
+    year_str = '_to_'.join([str(x) for x in years])
     out_dir = Path(out_dir/f'{year_str}')
     config['out_dir'] = out_dir
     config['year_str'] = year_str

--- a/forcing_prep/generate.py
+++ b/forcing_prep/generate.py
@@ -171,8 +171,6 @@ if __name__ == "__main__":
 
     forcing = xr.open_mfdataset(files, engine="zarr", parallel=True, consolidated=True)
 
-    gpkgs = [_basin_url.format(basin_id=id) for id in basins]
-
     proj = forcing[next(iter(forcing.keys()))].crs
     print(proj)
 

--- a/forcing_prep/generate.py
+++ b/forcing_prep/generate.py
@@ -148,6 +148,7 @@ def generate_forcing(gdf: gpd.GeoDataFrame, kwargs: dict) -> None:
     # save to netcdf is requested
     if nc_out:
         to_ngen_netcdf(df, out_dir, uniq_name)
+        path = out_dir
     else:
         df = df.to_dataframe()
             
@@ -162,7 +163,7 @@ def generate_forcing(gdf: gpd.GeoDataFrame, kwargs: dict) -> None:
     # See comment at end of to_ngen_netcdf for why this is still done in csv for now
     df = df.to_dataframe()
     agg = df.groupby("time").mean()
-    agg.to_csv(path / f"camels_{uniq_name}_agg.csv")
+    agg.to_csv(path / f"{uniq_name}_agg.csv")
 
 if __name__ == "__main__":
 

--- a/forcing_prep/requirements.txt
+++ b/forcing_prep/requirements.txt
@@ -6,3 +6,4 @@ rioxarray
 s3fs
 xarray
 zarr
+netCDF4

--- a/forcing_prep/weights.py
+++ b/forcing_prep/weights.py
@@ -37,14 +37,14 @@ def get_weights_df(gdf: gpd.GeoDataFrame, raster: xr.DataArray) -> pd.DataFrame:
         print("WARNING the following features couldn't be extracted by exact extract: ")
         print(missing.index)
         print("Assigning them to nearest neighbor values")
-    nearest = gdf[gdf["divide_id"].isin(missing.index)]
-    gdf = gdf.drop(nearest.index)
-    test = gpd.sjoin_nearest(gdf, nearest, how="right", distance_col="dist")
-    mapping = test[["divide_id_left", "divide_id_right"]].groupby("divide_id_right")
+        nearest = gdf[gdf["divide_id"].isin(missing.index)]
+        gdf = gdf.drop(nearest.index)
+        test = gpd.sjoin_nearest(gdf, nearest, how="right", distance_col="dist")
+        mapping = test[["divide_id_left", "divide_id_right"]].groupby("divide_id_right")
 
-    for name, group in mapping:
-        copy_from = output.loc[group.iloc[0]["divide_id_left"]]
-        output.loc[name] = copy_from
+        for name, group in mapping:
+            copy_from = output.loc[group.iloc[0]["divide_id_left"]]
+            output.loc[name] = copy_from
 
     # turns out this wasn't problem, but could be at some point...
     # TODO test exact extract's behavoir on features on the edge of the


### PR DESCRIPTION
These changes make netcdf outputs default, but still allow csv files to be generated by setting the following config key:
`netcdf: false`

Additionally, if one wants to process a single non-camels hydrofabric, a new `gpkg` key was added which will process just that specified hydrofabric input and ignore the camels/basins configuration blocks.