### PR TITLE
Track basins processed

### DIFF
--- a/forcing_prep/generate.py
+++ b/forcing_prep/generate.py
@@ -235,6 +235,7 @@ if __name__ == "__main__":
         generate_forcing(gdf, config)
     else:
         for b in basins:
+            config['year_str'] = year_str
             # read the geopackage from s3
             gdf = gpd.read_file(
                 _s3.open(_basin_url.format(basin_id=b)), driver="gpkg", layer="divides"

--- a/forcing_prep/generate.py
+++ b/forcing_prep/generate.py
@@ -144,6 +144,10 @@ def generate_forcing(gdf: gpd.GeoDataFrame, kwargs: dict) -> None:
     nc_out = kwargs.pop('netcdf', True)
     uniq_name = f'{name}_{year_str}'
 
+    log_file = Path(out_dir) / "processing_log.txt"
+    with open(log_file, 'a') as log:
+        log.write(f"{name}: processing\n")
+
     df = process_geo_data(gdf, forcing, name, **kwargs)
     # save to netcdf is requested
     if nc_out:
@@ -164,6 +168,9 @@ def generate_forcing(gdf: gpd.GeoDataFrame, kwargs: dict) -> None:
     df = df.to_dataframe()
     agg = df.groupby("time").mean()
     agg.to_csv(path / f"{uniq_name}_agg.csv")
+
+    with open(log_file, 'a') as log:
+        log.write(f"{name}: finished\n")
 
 if __name__ == "__main__":
 
@@ -229,13 +236,26 @@ if __name__ == "__main__":
     proj = forcing[next(iter(forcing.keys()))].crs
     print(proj)
     
+    # Ensure the processing log file exists
+    log_file = Path(out_dir) / "processing_log.txt"
+    if not log_file.exists():
+        log_file.touch()
+
     if gpkg is not None:
         gdf = gpd.read_file(gpkg, driver="gpkg", layer="divides").to_crs(proj)
         config['name'] = gpkg.stem
         generate_forcing(gdf, config)
     else:
         for b in basins:
+            
+            # Don't duplicate the data processing.
+            if (out_dir / f"{b}_coverage.parquet").exists():
+                print(f"{b} already processed, skipping.")
+                continue
+
+            # This is a bug, this line should be unneccessary, but this is the simple fix I could fine.
             config['year_str'] = year_str
+
             # read the geopackage from s3
             gdf = gpd.read_file(
                 _s3.open(_basin_url.format(basin_id=b)), driver="gpkg", layer="divides"

--- a/forcing_prep/run.slurm
+++ b/forcing_prep/run.slurm
@@ -1,0 +1,19 @@
+#!/bin/bash
+#SBATCH --job-name=camels_aorc_1980_2000         # Job name
+#SBATCH --partition=normal             # Partition (queue) name
+#SBATCH --nodes=1                      # Number of nodes
+#SBATCH --ntasks=40                    # Number of tasks (processes)
+#SBATCH --time=48:00:00                 # Time limit hrs:min:sec
+#SBATCH --output=aorc_%j.log    # Standard output and error log
+
+source /home/jmframe/CIROH_DL_NextGen/forcing_prep/venv/bin/activate 
+
+cd /home/jmframe/CIROH_DL_NextGen/forcing_prep
+
+# Ensure the generate script is executable
+chmod +x generate.py
+
+python3 generate.py "config_aorc.yaml"
+
+deactivate
+


### PR DESCRIPTION
Adds a file to the years_str directory to log the files that are being processed, and then logs them when done.

The basin loop now checks what basins have been processed, via the log file, then skips the basins that are being processed or have finished process. that way, we can run multiple instances without the chance of duplicating basins.