### PR TITLE
Process geopackage files locally for HRRR processing

### DIFF
--- a/forcing_prep/aggregate.py
+++ b/forcing_prep/aggregate.py
@@ -1,8 +1,12 @@
 """aggregate.py
-Module for jagged window wieghted mean aggregration
+    Module for jagged window wieghted mean aggregration
 
-@author Nels Frazier <nfrazier@lynker.com>
-@version 0.1
+    Authors
+    -------
+    Guy Litt <glitt@lynker.com>
+    Nels Frazier <nfrazier@lynker.com>
+    Version
+    -------
 """
 
 import numpy as np

--- a/forcing_prep/config_hrrr_localgpkg.yaml
+++ b/forcing_prep/config_hrrr_localgpkg.yaml
@@ -1,0 +1,35 @@
+hrrr_source: 's3://hrrrzarr/sfc' # url of HRRR data stored as zarr files in s3
+basin_url_template: "s3://lynker-spatial/hydrofabric/v20.1/camels/Gage_{}.gpkg" # URL of CAMELS basin geopackages
+basins:
+  #- 1022500 #may list out basins of interest, or simply specify 'all'
+  - 'all'
+time_bgn: '2018-07-13' # YYYY-MM-DD, The earliest HRRR zarr data with precipitation begins on '2018-07-13'
+time_end: '2024-05-30' # YYYY-MM-DD
+
+cvar: 8 # Chunk size for variables. Default 8.
+ctime_max: 120 # The max chunk time frame. Units of hours.
+cid: -1 # The divide_id chunk size. Default -1 means all divide_ids in a basin. A small value may be needed for very large basins with many catchments.
+redo: false # Set to true if you want to ensure intermediate data files not read in from local storage
+
+dir_custom_gpkg: "{home_dir}/noaa/camels/gagesII_wood" # OPTIONAL. The location where geopackage data are stored locally (in-case hydrofabric gpkg files undesired)
+out_dir: "{home_dir}/noaa/data/hrrr/out_gagesII" # The local storage data output directory. 
+id_col: 'hru_id'
+
+x_lon_dim: 'projection_x_coordinate' # The longitude term in the HRRR dataset
+y_lat_dim: 'projection_y_coordinate' # The latitude term in the HRRR dataset
+level_vars_anl: # These are the non-forecasted data variables
+  - '2m_above_ground/TMP'
+  - '2m_above_ground/SPFH'
+  - 'surface/DLWRF'
+  - 'surface/DSWRF'
+  - 'surface/PRES'
+  - '10m_above_ground/UGRD'
+  - '10m_above_ground/VGRD'
+level_vars_fcst: # These are the forecasted data variables (likely only precip)
+  - 'surface/APCP_1hr_acc_fcst'
+fcst_hr: 0 # The hours into the future forecast for variables specified in level_vars_fcst. Default 0 means the nowcast. Must be >= 0 up to the max HRRR forecast hours (12 hours???).
+drop_vars: # Ignore these variables when merging forecast and nowcast xarray.Dataset objects. Default should likely just be ['forecast_period','forecast_reference_time'] 
+ - 'forecast_period'
+ - 'forecast_reference_time'
+ - 'height'
+ - 'pressure' 

--- a/forcing_prep/config_hrrr_localgpkg.yaml
+++ b/forcing_prep/config_hrrr_localgpkg.yaml
@@ -1,7 +1,8 @@
 hrrr_source: 's3://hrrrzarr/sfc' # url of HRRR data stored as zarr files in s3
 basin_url_template: "s3://lynker-spatial/hydrofabric/v20.1/camels/Gage_{}.gpkg" # URL of CAMELS basin geopackages
 basins:
-  #- 1022500 #may list out basins of interest, or simply specify 'all'
+  #- "1195100"
+  # - "1022500" #may list out basins of interest, or simply specify 'all'
   - 'all'
 time_bgn: '2018-07-13' # YYYY-MM-DD, The earliest HRRR zarr data with precipitation begins on '2018-07-13'
 time_end: '2024-05-30' # YYYY-MM-DD
@@ -9,11 +10,13 @@ time_end: '2024-05-30' # YYYY-MM-DD
 cvar: 8 # Chunk size for variables. Default 8.
 ctime_max: 120 # The max chunk time frame. Units of hours.
 cid: -1 # The divide_id chunk size. Default -1 means all divide_ids in a basin. A small value may be needed for very large basins with many catchments.
-redo: false # Set to true if you want to ensure intermediate data files not read in from local storage
+redo: True # Set to true if you want to ensure intermediate data files not read in from local storage (in the case of the HRRR data, this should be True!!!!)
 
+out_dir: "{home_dir}/noaa/data/hrrr/out_gagesII_lambconf" # The local storage data output directory. 
 dir_custom_gpkg: "{home_dir}/noaa/camels/gagesII_wood" # OPTIONAL. The location where geopackage data are stored locally (in-case hydrofabric gpkg files undesired)
-out_dir: "{home_dir}/noaa/data/hrrr/out_gagesII" # The local storage data output directory. 
+epsg: 4326 # the CRS of the locally stored geopackage data (if not using hydrofabric)
 id_col: 'hru_id'
+
 
 x_lon_dim: 'projection_x_coordinate' # The longitude term in the HRRR dataset
 y_lat_dim: 'projection_y_coordinate' # The latitude term in the HRRR dataset

--- a/forcing_prep/generate.py
+++ b/forcing_prep/generate.py
@@ -1,21 +1,25 @@
 #!/usr/bin/env python
-"""generate.py
-@title: Process AORC forcings into timeseries for CAMELS basins & subcatchments
-@author: Nels Frazier <nfrazier@lynker.com>
-@author: Guy Litt <glitt@lynker.com>
-@description: Entrypoint for resampling zarr based aorc to hy_features catchments
-@details: Saves to file the following outputs:
+""" Process AORC forcings into timeseries for CAMELS basins & subcatchments
+Entrypoint for resampling zarr based AORC to hy_features catchments.
+
+    Saves to file the following outputs:
     - Individual subcatchment forcing timeseries saved as f'{out_dir}/{year_str}/camels_{basin_id}_{year_str}/cat-{subcatchment_id}}.csv'
         where year_str = {year_begin}_to_{year_end}, e.g. '1979_to_2023'
     - Aggregated basin forcing timeseries saved as f'{out_dir}/{year_str}/camels_{basin_id}_{year_str}/{basin_id}_{year_str}_agg.csv'
     - Basin AORC coverage weightings saved as f'{out_dir}/{year_str}/{basin_id}_{year_str}_coverage.parquet'
 
-@version: 0.2
-@example: python /path/to/git/CIROH_DL_NextGen/forcing_prep/generate.py "/path/to/git/CIROH_DL_NextGen/forcing_prep/config_aorc.yaml" 
-Changelog/Contributions
- - version 0.1, originally created, NF
- - version 0.2, added yaml config, configurable arguments, define output directories, minor bugfixes, GL
+    Authors
+    -------
+    Nels Frazier <nfrazier@lynker.com>
+    Guy Litt <glitt@lynker.com>
 
+    Version
+    -------
+    0.2
+
+    Example
+    -------
+    python /path/to/git/CIROH_DL_NextGen/forcing_prep/generate.py "/path/to/git/CIROH_DL_NextGen/forcing_prep/config_aorc.yaml"
 """
 import argparse
 import yaml

--- a/forcing_prep/generate_hrrr.py
+++ b/forcing_prep/generate_hrrr.py
@@ -1,19 +1,34 @@
 '''
-@title: Process HRRR forcings into timeseries for CAMELS basins & subcatchments
-@author: Guy Litt <glitt@lynker.com>
-@author: Nels Frazier <nfrazier@lynker.com>
-@description: Entrypoint for resampling zarr based hrrr to hy_features catchments
-@details: Saves to file the following outputs:
+Process HRRR forcings into timeseries for CAMELS basins & subcatchments.
+
+    Entrypoint for resampling zarr based HRRR to hy_features catchments.
+
+    Saves to file the following outputs:
     - Individual subcatchment forcing timeseries saved as f'{out_dir}/{year_str}/camels_{basin_id}_{year_str}/cat-{subcatchment_id}}.csv'
         where year_str = {year_begin}_to_{year_end}, e.g. '1979_to_2023'
     - Aggregated basin forcing timeseries saved as f'{out_dir}/{year_str}/camels_{basin_id}_{year_str}/{basin_id}_{year_str}_agg.csv'
     - Basin AORC coverage weightings saved as f'{out_dir}/{year_str}/{basin_id}_{year_str}_coverage.parquet'
-@seealso: generate.py for processing AORC data
-@version: 0.1
-@example: python /path/to/git/CIROH_DL_NextGen/forcing_prep/generate_hrrr.py "/path/to/git/CIROH_DL_NextGen/forcing_prep/config_hrrr.yaml" 
 
-Changelog/Contributions
- - version 0.1, 2024-06-20 adapted AORC processing to HRRR processing, GL
+    See Also
+    --------
+    generate.py for processing AORC data
+
+    Authors
+    -------
+    Guy Litt <glitt@lynker.com>
+    Nels Frazier <nfrazier@lynker.com>
+
+    Version
+    -------
+    0.1
+
+    Example
+    -------
+    python /path/to/git/CIROH_DL_NextGen/forcing_prep/generate_hrrr.py "/path/to/git/CIROH_DL_NextGen/forcing_prep/config_hrrr.yaml"
+
+    Changelog / Contributions
+    -------------------------
+    2024-06-20: Adapted AORC processing to HRRR processing, GL
 
 '''
 import argparse

--- a/forcing_prep/geo_proc.py
+++ b/forcing_prep/geo_proc.py
@@ -1,12 +1,15 @@
-'''
-@title: Process weights of raster grid data spanning catchment boundaries
-@author: Nels Frazier <nfrazier@lynker.com>
-@author: Guy Litt <glitt@lynker.com>
+'''Process weights of raster grid data spanning catchment boundaries.
 
-# Changelog / contributions
-    2024-May Originally created, NF
-    2024-06-18 minor adaptations to flipped dataset check, data selection NF, GL
-    2024-06-27 expand slicing dimension coverage if first attempt at computing weights fails, GL
+    Authors
+    -------
+    Nels Frazier <nfrazier@lynker.com>
+    Guy Litt <glitt@lynker.com>
+
+    Changelog / Contributions
+    -------------------------
+    2024-May: Originally created, NF
+    2024-06-18: Minor adaptations to flipped dataset check, data selection, NF, GL
+    2024-06-27: Expand slicing dimension coverage if first attempt at computing weights fails, GL
 '''
 
 
@@ -28,18 +31,35 @@ from weights import get_all_cov, get_weights_df
 
 def process_geo_data(gdf, data, name, y_lat_dim, x_lon_dim,out_dir = '', redo = False, cvar = 8, ctime_max = 120, cid = -1):
     '''
-    @description: Given a geodataframe representing catchment(s) boundaries and a raster dataset,
+   Given a geodataframe representing catchment(s) boundaries and a raster dataset,
     compute the mean data values spanning the catchment(s) boundaries.
-    @param: gdf  geodataframe of catchments
-    @param: data xarray dataset of raster data
-    @param: name A unique file name used for saving catchment-specific grid weights. The basin id is ideal.
-    @param: y_lat_dim the latitude identifier in the xarray dataset \code{data}
-    @param: x_lon_dim the longitude identifier in the xarray dataset \code{data}
-    @param: out_dir the desired save directory for catchment-specific grid weights
-    @param: redo boolean default False. Should previously saved catchment grid weights be read in if they have already been created? If False, weights are regenerated
-    @param: cvar int default 8; Chunk size for variables. Default 8.
-    @param: ctime_max int default 120; The max chunk time frame. Units of hours.
-    @param: cid int default -1; The divide_id chunk size. Default -1 means all divide_ids in a basin. A small value may be needed for very large basins with many catchments.
+
+    Parameters
+    ----------
+    gdf : GeoDataFrame
+        Geodataframe of catchments.
+    data : xarray.Dataset
+        Xarray dataset of raster data.
+    name : str
+        A unique file name used for saving catchment-specific grid weights. The basin id is ideal.
+    y_lat_dim : str
+        The latitude identifier in the xarray dataset `data`.
+    x_lon_dim : str
+        The longitude identifier in the xarray dataset `data`.
+    out_dir : str
+        The desired save directory for catchment-specific grid weights.
+    redo : bool, optional
+        Should previously saved catchment grid weights be read in if they have already been created? If False, weights are regenerated. Default is False.
+    cvar : int, optional
+        Chunk size for variables. Default is 8.
+    ctime_max : int, optional
+        The max chunk time frame. Units of hours. Default is 120.
+    cid : int, optional
+        The divide_id chunk size. Default is -1, which means all divide_ids in a basin. A small value may be needed for very large basins with many catchments.
+
+    Returns
+    -------
+    xr.dataset of retrieved variables
     '''
     print("Slicing data to domain")
     # Only need to load the raster for the geo data extent

--- a/forcing_prep/geo_proc.py
+++ b/forcing_prep/geo_proc.py
@@ -115,7 +115,7 @@ def process_geo_data(gdf, data, name, y_lat_dim, x_lon_dim, id_col = 'divide_id'
         coverage = get_all_cov(data, weights_df, y_lat_dim = y_lat_dim, x_lon_dim = x_lon_dim)
         coverage.to_parquet(save)
     print("Processing the following raster data set")
-    print(data)
+    #print(data)
     # Stack all the raster variables into a single multi-dimension array
     # This makes the windowing algorithm much more efficient as it can broadcast
     # operations arcoss all the variable data at once
@@ -154,7 +154,12 @@ def process_geo_data(gdf, data, name, y_lat_dim, x_lon_dim, id_col = 'divide_id'
     result = data.map_blocks(window_aggregate, args=(coverage,), template=var)
     # Perform the computations
     with ProgressBar():
-        result = result.compute()
+        try:
+            result = result.compute()
+        except:
+            print("TODO: is there a dimensional out of bounds problem? Try and figure this out")
+            # print("Attempting without chunking/window aggregation")
+            # result = data.compute()
     # Unstack the variables back into a dataset
     result = result.to_dataset(dim="variable")
     return result

--- a/forcing_prep/geo_proc.py
+++ b/forcing_prep/geo_proc.py
@@ -109,7 +109,7 @@ def process_geo_data(gdf, data, name, y_lat_dim, x_lon_dim, id_col = 'divide_id'
                 .sel(indexers = {x_lon_dim:lons_big, y_lat_dim:lats_big})
                 .compute()
             )
-            weights_df = get_weights_df(gdf, weight_raster)
+            weights_df = get_weights_df(gdf, weight_raster,id_col=id_col)
             data = biggerdata
         print("Creating Coverage")
         coverage = get_all_cov(data, weights_df, y_lat_dim = y_lat_dim, x_lon_dim = x_lon_dim)

--- a/forcing_prep/geo_proc.py
+++ b/forcing_prep/geo_proc.py
@@ -59,6 +59,8 @@ def process_geo_data(gdf, data, name, y_lat_dim, x_lon_dim,out_dir = '', redo = 
     if save.exists() and redo != True:
         print(f"Reading {name} coverage from file")
         coverage = ddf.read_parquet(save).compute()
+        data = data_sub
+        #NJF FIXME this isn't quite right if coverage is created based on biggerdata below?????
     else:
         # If we don't have weights cached, compute and save them
         weight_raster = (
@@ -70,6 +72,7 @@ def process_geo_data(gdf, data, name, y_lat_dim, x_lon_dim,out_dir = '', redo = 
         print("Computing Weights")
         try:
             weights_df = get_weights_df(gdf, weight_raster)
+            data = data_sub
         except:
             print('weight_raster may not have enough coverage. Try expanding size of sliced raster')
             x_lon_diff = data[x_lon_dim][1].values - data[x_lon_dim][0].values
@@ -87,6 +90,7 @@ def process_geo_data(gdf, data, name, y_lat_dim, x_lon_dim,out_dir = '', redo = 
                 .compute()
             )
             weights_df = get_weights_df(gdf, weight_raster)
+            data = biggerdata
         print("Creating Coverage")
         coverage = get_all_cov(data, weights_df, y_lat_dim = y_lat_dim, x_lon_dim = x_lon_dim)
         coverage.to_parquet(save)

--- a/forcing_prep/hrrr_proc.py
+++ b/forcing_prep/hrrr_proc.py
@@ -195,7 +195,7 @@ def _map_open_files_hrrrzarr(urls_ls, concat_dim = ['time',None], preprocess = N
 
                         if not all([x in check.data_vars for x in must_have_vars]): # Example 20200318_22z DSWRF
                             # Expected variables include 'time' and the var_name
-                            print(f'Skipping {var_name} because {' & '.join(must_have_vars)} are not present as variables in the dataset from {hr}. ')
+                            print(f"Skipping {var_name} because {' & '.join(must_have_vars)} are not present as variables in the dataset from {hr}. ")
                             continue
                     except: # Skip this one and head to the next
                         print(f'Could not process {hr}. Skipping. Consider the preprocess function or faulty zarr data.')

--- a/forcing_prep/hrrr_proc.py
+++ b/forcing_prep/hrrr_proc.py
@@ -93,15 +93,29 @@ def _gen_hrrr_zarr_urls(date, level_vars_anl = None, level_vars_fcst=None, fcst_
 def _check_hrrrzarr_url_time_vs_data_time(urls_ls, ls_vars,drop_vars=None,fcst_hr = 0):
     '''
     Checks to see if any timestamps specified in a zarr url do not agree
-     with timestamps retrieved in data, and provides new data if needed.
-    @param: urls_ls A list of urls organized by var[timebythehour[zarr url, metadata url]]
-    @param: ls_vars: A list of datasets, each list item unique to a HRRR variable
-    @param: fcst_hr, int default 0. Number of hours into the future of a forecast, used in generating urls_ls and processing ls_vars
-    @return: subdat_ls, ls_wrong_ts where subdat_ls is a new version of ls_vars, and ls_wrong_ts is a list of boolean if any variable changed
-    @seealso: _map_open_files_hrrrzarr()
+    with timestamps retrieved in data, and provides new data if needed.
 
-    Changelog 
-        - 2024-06-25 adapt time concurrence check to account for forecast hour, GL
+    Parameters
+    ----------
+    urls_ls : list
+        A list of urls organized by var[timebythehour[zarr url, metadata url]].
+    ls_vars : list
+        A list of datasets, each list item unique to a HRRR variable.
+    fcst_hr : int, optional
+        Number of hours into the future of a forecast, used in generating urls_ls and processing ls_vars. Default is 0.
+
+    Returns
+    -------
+    tuple
+        subdat_ls, ls_wrong_ts where subdat_ls is a new version of ls_vars, and ls_wrong_ts is a list of boolean if any variable changed.
+
+    See Also
+    --------
+    _map_open_files_hrrrzarr
+
+    Changelog
+    ---------
+    2024-06-25: Adapt time concurrence check to account for forecast hour, GL
 
     '''
     ctr_ls = -1

--- a/forcing_prep/post_process_hrrr.py
+++ b/forcing_prep/post_process_hrrr.py
@@ -1,0 +1,48 @@
+"""
+Post-process HRRR data into individual dataframes of HRRR timeseries for each basin
+
+Perform after running generate_hrrr.py
+
+Usage:
+python /path/to/post_process_hrrr.py "/path/to/config_hrrr_localgpkg.yaml" "/path/to/output/directory"
+"""
+import argparse
+import yaml
+from pathlib import Path
+import pandas as pd
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(description='Process the YAML config file.')
+    parser.add_argument('config_path', type=str, help='Path to the YAML configuration file')
+    parser.add_argument('dir_write',type= str, help="Directory location to write output")
+    args = parser.parse_args()
+
+    
+    # Load the YAML configuration file
+    with open(args.config_path, 'r') as file:
+        config = yaml.safe_load(file)
+
+    
+    home_dir = Path.home()
+    dir_write = Path(args.dir_write.format(home_dir=home_dir))
+    out_dir = Path(config['out_dir'].format(home_dir=home_dir)) # out_dir = f'{Path.home()}/noaa/data/hrrr/redo'
+    
+    subdirs = [p for p in out_dir.rglob('*') if p.is_dir()]
+
+    subfiles = [f for f in out_dir.rglob('*.parquet')] # Should contain all basin identifiers
+
+    basin_ids = [f.name.replace('_coverage.parquet','') for f in subfiles]
+
+    for b in basin_ids:
+        paths_agg = [f for sd1 in subdirs for f in sd1.iterdir()  if f.is_file and b in f.name and 'agg.csv' in f.name]
+        paths_non_agg = [f for sd1 in subdirs for f in sd1.iterdir()  if f.is_file and b in f.name and 'agg.csv' not in f.name]
+
+        compiled_df = pd.concat([pd.read_csv(x) for x in paths_agg]).sort_values(by = 'time', ascending=True).reset_index()
+
+        name_compiled_df = f'HRRR_ts_gage_{b}.csv'
+        
+        path_compiled = Path(dir_write/Path(name_compiled_df))
+        compiled_df.to_csv(path_compiled,  index=False)
+        
+
+    

--- a/forcing_prep/requirements.txt
+++ b/forcing_prep/requirements.txt
@@ -7,3 +7,4 @@ s3fs
 xarray
 zarr
 netCDF4
+cartopy

--- a/forcing_prep/requirements.txt
+++ b/forcing_prep/requirements.txt
@@ -7,4 +7,5 @@ s3fs
 xarray
 zarr
 netCDF4
-cartopy
+cartopy # For HRRR processing
+pyogrio # For HRRR processing

--- a/forcing_prep/weights.py
+++ b/forcing_prep/weights.py
@@ -1,8 +1,13 @@
 """weights.py
-Module for computing polygon based raster weights
+    Module for computing polygon based raster weights
 
-@author Nels Frazier <nfrazier@lynker.com>
-@version 0.1
+    Author
+    -------
+    Nels Frazier <nfrazier@lynker.com>
+
+    Version
+    -------
+    0.1
 """
 
 import dask


### PR DESCRIPTION
Modified the HRRR processing, which now allows user to point to a local directory containing geopackage files of interest (rather than download gpkg files from hydrofabric). Refer to the config file config_hrrr_localgpkg.yaml for the example. The key here is to ensure `dir_custom_gpkg` and `id_col` are designated appropriately.